### PR TITLE
Bundle FullCalendar styles

### DIFF
--- a/ifitwala_ed/public/css/fullcalendar.css
+++ b/ifitwala_ed/public/css/fullcalendar.css
@@ -1,0 +1,4 @@
+@import '@fullcalendar-css/core/index.css';
+@import '@fullcalendar-css/daygrid/index.css';
+@import '@fullcalendar-css/timegrid/index.css';
+@import '@fullcalendar-css/list/index.css';

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -38,16 +38,16 @@ function contentHash(file) {
 const portalHash = contentHash(path.join(portalSrc, 'index.js'));
 
 const basePlugins = [
-	resolve(),
-	commonjs(),
-	alias({
-		entries: [
-			{
-				find: '@fullcalendar-css',
-				replacement: path.resolve(projectRootDir, 'node_modules/@fullcalendar'),
-			},
-		],
-	}),
+        alias({
+                entries: [
+                        {
+                                find: '@fullcalendar-css',
+                                replacement: path.resolve(projectRootDir, 'node_modules/@fullcalendar'),
+                        },
+                ],
+        }),
+        resolve(),
+        commonjs(),
 ];
 
 /* ─── Build matrix ─────────────────────────────────────────────────── */
@@ -76,18 +76,31 @@ module.exports = [
 		]
 	},
 
-	// ── Other desk pages CSS ──
-	{
-		input: 'ifitwala_ed/public/css/other_desk_pages.css',
-		output: { dir: '.' },
-		plugins: [
-			postcss({
-				extract: `${dist}/other_desk_pages.min.css`,
-				minimize: true,
-				plugins: [require('autoprefixer')],
-			}),
-		],
-	},
+        // ── Other desk pages CSS ──
+        {
+                input: 'ifitwala_ed/public/css/other_desk_pages.css',
+                output: { dir: '.' },
+                plugins: [
+                        postcss({
+                                extract: `${dist}/other_desk_pages.min.css`,
+                                minimize: true,
+                                plugins: [require('autoprefixer')],
+                        }),
+                ],
+        },
+
+        // ── Desk FullCalendar CSS ──
+        {
+                input: 'ifitwala_ed/public/css/fullcalendar.css',
+                output: { dir: '.' },
+                plugins: [
+                        postcss({
+                                extract: `${dist}/ifitwala_ed.bundle.css`,
+                                minimize: true,
+                                plugins: [require('autoprefixer')],
+                        }),
+                ],
+        },
 
 	// ── Website JS ──
 	{


### PR DESCRIPTION
## Summary
- ensure alias for FullCalendar resolves before other plugins
- add a CSS entry importing FullCalendar styles
- output `ifitwala_ed.bundle.css` via Rollup

## Testing
- `yarn build` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6841769184808326b7e8118f88ae9d95