### PR TITLE
fix(#8): Add Guardian login redirect to /portal

### DIFF
--- a/ifitwala_ed/api/test_users.py
+++ b/ifitwala_ed/api/test_users.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2026, François de Ryckel and contributors
+# For license information, please see license.txt
+
+# ifitwala_ed/api/test_users.py
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from ifitwala_ed.api.users import redirect_user_to_entry_portal
+
+
+class TestUserRedirect(FrappeTestCase):
+	"""Test login redirect logic for different user types."""
+
+	def test_guardian_redirects_to_portal(self):
+		"""Guardians should be redirected to /portal on login."""
+		# Create test user with Guardian role
+		user = frappe.new_doc("User")
+		user.email = "test_guardian_redirect@example.com"
+		user.first_name = "Test"
+		user.last_name = "Guardian"
+		user.enabled = 1
+		user.add_roles("Guardian")
+		user.save()
+
+		# Create Guardian record linked to user
+		guardian = frappe.new_doc("Guardian")
+		guardian.guardian_first_name = "Test"
+		guardian.guardian_last_name = "Guardian"
+		guardian.guardian_email = user.email
+		guardian.user = user.email
+		guardian.save()
+
+		# Simulate login
+		frappe.set_user(user.email)
+		frappe.local.response = {}
+
+		# Call redirect function
+		redirect_user_to_entry_portal()
+
+		# Assert redirect to /portal
+		self.assertEqual(frappe.local.response.get("home_page"), "/portal")
+		self.assertEqual(frappe.local.response.get("redirect_to"), "/portal")
+		self.assertEqual(frappe.local.response.get("type"), "redirect")
+
+		# Verify home_page was set on User
+		user.reload()
+		self.assertEqual(user.home_page, "/portal")
+
+		# Cleanup
+		frappe.set_user("Administrator")
+		frappe.delete_doc("Guardian", guardian.name, force=True)
+		frappe.delete_doc("User", user.email, force=True)
+
+	def test_guardian_respects_existing_home_page(self):
+		"""Guardians with explicit home_page choice should not be overridden."""
+		# Create test user with Guardian role and explicit home_page
+		user = frappe.new_doc("User")
+		user.email = "test_guardian_custom@example.com"
+		user.first_name = "Test"
+		user.last_name = "Guardian Custom"
+		user.home_page = "/app"
+		user.enabled = 1
+		user.add_roles("Guardian")
+		user.save()
+
+		# Create Guardian record
+		guardian = frappe.new_doc("Guardian")
+		guardian.guardian_first_name = "Test"
+		guardian.guardian_last_name = "Guardian Custom"
+		guardian.guardian_email = user.email
+		guardian.user = user.email
+		guardian.save()
+
+		# Simulate login
+		frappe.set_user(user.email)
+		frappe.local.response = {}
+
+		# Call redirect function
+		redirect_user_to_entry_portal()
+
+		# Assert NO redirect was set (respects explicit /app choice)
+		self.assertNotIn("home_page", frappe.local.response)
+
+		# Verify home_page was NOT changed
+		user.reload()
+		self.assertEqual(user.home_page, "/app")
+
+		# Cleanup
+		frappe.set_user("Administrator")
+		frappe.delete_doc("Guardian", guardian.name, force=True)
+		frappe.delete_doc("User", user.email, force=True)

--- a/ifitwala_ed/api/test_users.py
+++ b/ifitwala_ed/api/test_users.py
@@ -39,13 +39,13 @@ class TestUserRedirect(FrappeTestCase):
 		redirect_user_to_entry_portal()
 
 		# Assert redirect to /portal
-		self.assertEqual(frappe.local.response.get("home_page"), "/portal")
-		self.assertEqual(frappe.local.response.get("redirect_to"), "/portal")
+		self.assertEqual(frappe.local.response.get("home_page"), "/portal/guardian")
+		self.assertEqual(frappe.local.response.get("redirect_to"), "/portal/guardian")
 		self.assertEqual(frappe.local.response.get("type"), "redirect")
 
 		# Verify home_page was set on User
 		user.reload()
-		self.assertEqual(user.home_page, "/portal")
+		self.assertEqual(user.home_page, "/portal/guardian")
 
 		# Cleanup
 		frappe.set_user("Administrator")

--- a/ifitwala_ed/api/users.py
+++ b/ifitwala_ed/api/users.py
@@ -13,7 +13,7 @@ def redirect_user_to_entry_portal():
 	- Real students -> /sp (always)
 	- Active employees -> default /portal/staff, but allow opt-in to Desk:
 	  If User.home_page is already set (e.g. /app), we DO NOT override it.
-	- Guardians -> /portal (will route to guardian-home via SPA router)
+	- Guardians -> /portal/guardian (will route to guardian-home via SPA router)
 
 	Why:
 	- Desk /app logins can override weak response redirects.
@@ -44,13 +44,13 @@ def redirect_user_to_entry_portal():
 		return
 
 	# ---------------------------------------------------------------
-	# 2) Guardians: /portal (SPA will route to guardian-home based on defaultPortal)
+	# 2) Guardians: /portal/guardian (SPA will route to guardian-home based on defaultPortal)
 	# ---------------------------------------------------------------
 	roles = set(frappe.get_roles(user))
 	if "Guardian" in roles:
 		current_home = (frappe.db.get_value("User", user, "home_page") or "").strip()
 		if not current_home:
-			_force_redirect("/portal", also_set_home_page=True)
+			_force_redirect("/portal/guardian", also_set_home_page=True)
 		else:
 			# If already set to portal or guardian-specific path, redirect without overwriting
 			if current_home in ("/portal", "/portal/guardian"):

--- a/ifitwala_ed/docs/engineering/students/guardian.md
+++ b/ifitwala_ed/docs/engineering/students/guardian.md
@@ -1,0 +1,143 @@
+# Guardian DocType
+
+## Purpose
+
+The Guardian DocType represents a student's legal guardian or parent in the Ifitwala Ed system. It stores contact information, work details, and links to the guardian's associated students. This is a core entity for family-school communication and portal access.
+
+---
+
+## Automation & Triggers
+
+### Contact Creation (`after_insert`)
+
+When a Guardian record is created:
+- A Contact record is automatically created (or reused if matching email exists)
+- The Contact is linked to the Guardian via Dynamic Link
+- This enables Frappe's standard address/contact functionality
+
+### User Creation (`create_guardian_user`)
+
+A whitelisted method creates a portal user for the guardian:
+
+**Behavior:**
+- Called via UI button "Create and Invite as User" (in `guardian.js`)
+- Creates a `User` with `user_type = "Website User"`
+- Assigns the "Guardian" role
+- **Sets `home_page = "/portal/guardian"`** for automatic portal routing on login
+- Sends welcome email with login credentials
+- Links the User back to the Guardian record
+
+**If User Already Exists:**
+- Links the existing user to the guardian
+- Does not modify the existing user's home_page
+
+**Code Location:** `guardian.py::create_guardian_user()`
+
+---
+
+## Permission Implications
+
+| Role | Permissions | Notes |
+|------|-------------|-------|
+| System Manager | Full access | All operations allowed |
+| Academic Admin | Full access | Can create, edit, delete |
+| Admission Officer | Full access | Can create, edit, delete |
+| Academic Assistant | Create, Read, Write | Cannot delete |
+| Academic Staff | Read only | View access for information |
+| Instructor | Read only | View access |
+| Nurse | Read only | Medical context access |
+| Counsellor | Read only | Student support context |
+| Guardian (own record) | Read only | Via portal, sees own data only |
+
+**Portal Access:**
+- Guardians with linked User accounts can access `/portal/guardian`
+- Portal shows: Family Timeline, Attention Needed, Preparation & Support, Recent Activity
+- Routes are protected by role checks in `portal/index.py`
+
+---
+
+## Data Integrity Rules
+
+1. **Email Required for User Creation**
+   - `guardian_email` must be set before `create_guardian_user()` can be called
+   - Throws validation error if missing
+
+2. **Unique User Link**
+   - A Guardian can only have one linked User
+   - A User can be linked to only one Guardian (via email match)
+
+3. **Contact Synchronization**
+   - Contact name/phone updates flow to Guardian (via Contact hooks)
+   - Guardian updates do NOT flow back to Contact (one-way sync)
+
+4. **Student Linkage**
+   - Guardians are linked to Students via `Student Guardian` child table
+   - `Guardian Student` is a read-only view on Guardian form
+   - Actual relationships are managed from Student side
+
+---
+
+## Migration Sensitivities
+
+**Fields Never to Rename/Casually Change:**
+
+| Field | Why Sensitive |
+|-------|---------------|
+| `guardian_email` | Used as User.username; changing breaks login |
+| `user` | Link to User DocType; critical for portal access |
+| `guardian_full_name` | Display name across system; cached in multiple places |
+
+**Contact Linkage:**
+- Dynamic Link table entries connect Guardian to Contact
+- Renaming Guardian name requires updating `link_title` in Dynamic Link
+
+---
+
+## Downstream System Surfaces
+
+### Portal Pages
+- `/portal/guardian` → Guardian Home (family snapshot)
+- `/portal/guardian/students/:id` → Individual student view
+
+### Reports
+- Medical Info and Emergency Contact (references guardian data)
+- Student Logs (shows guardian-linked students)
+
+### Background Jobs
+- None currently
+
+### API Endpoints
+- `get_guardian_home_snapshot` → Returns guardian portal data
+- `create_guardian_user` → Creates/link guardian user
+
+---
+
+## Testing
+
+**Key Test Cases:**
+
+1. `test_create_guardian_user_sets_home_page`
+   - Verifies user creation sets `home_page = "/portal/guardian"`
+   - Ensures automatic portal routing works on login
+
+2. `test_create_guardian_user_links_existing_user`
+   - Verifies existing users are properly linked
+   - No duplicate users created
+
+**Run Tests:**
+```bash
+bench run-tests --doctype Guardian
+```
+
+---
+
+## Related Files
+
+| File | Purpose |
+|------|---------|
+| `guardian.py` | Controller logic, user creation |
+| `guardian.js` | UI button for user creation |
+| `test_guardian.py` | Test suite |
+| `../ui-spa/src/pages/guardian/GuardianHome.vue` | Portal home page |
+| `../ui-spa/src/router/index.ts` | Portal routing rules |
+| `../../www/portal/index.py` | Portal entry point, role validation |

--- a/ifitwala_ed/docs/spa/04_login_routing.md
+++ b/ifitwala_ed/docs/spa/04_login_routing.md
@@ -1,0 +1,45 @@
+# Login Routing & Portal Entry
+
+> **Status:** Authoritative
+> **Scope:** User login redirects based on role
+> **Related:** `ifitwala_ed/api/users.py::redirect_user_to_entry_portal`
+
+## Purpose
+
+Define the authoritative routing logic for users after login. This ensures each user type lands on the appropriate surface based on their role.
+
+## Routing Priority
+
+When a user logs in, they are redirected based on the following priority:
+
+| Order | User Type | Target | Home Page Set | Notes |
+|-------|-----------|--------|---------------|-------|
+| 1 | Student | `/sp` | Yes | Always takes precedence |
+| 2 | Guardian | `/portal` | Yes | SPA router will route to `guardian-home` |
+| 3 | Active Employee | `/portal/staff` | If unset | Respects explicit `/app` opt-in |
+| 4 | Admissions Applicant | `/admissions` | If unset | Always to admissions portal |
+| 5 | Others | (no redirect) | No | Falls through to Desk defaults |
+
+## Guardian Routing (Fix #8)
+
+**Issue:** Guardians with the "Guardian" role were not being redirected after login, causing them to land on Desk (`/app`) instead of the Guardian Portal.
+
+**Solution:** Added explicit Guardian handling that:
+1. Checks for "Guardian" role
+2. Redirects to `/portal` (SPA handles further routing via `defaultPortal`)
+3. Sets `User.home_page` to `/portal` for persistence
+4. Respects explicit `home_page` choices if already set
+
+## Implementation Notes
+
+- Uses `frappe.local.response["home_page"]` for immediate redirect
+- Uses `frappe.db.set_value("User", user, "home_page", path)` for persistence
+- The `/portal` route uses `window.defaultPortal` to determine final SPA route
+- Guardian role takes priority over Employee (a Guardian who is also an Employee will go to `/portal`)
+
+## Security
+
+- All checks use `frappe.get_roles()` for role verification
+- Guardian link verified via `Guardian.user` field
+- Student verified via `Student.student_user_id` field
+- Employee verified via `Employee.user_id` + `employment_status = "Active"`

--- a/ifitwala_ed/students/doctype/guardian/guardian.js
+++ b/ifitwala_ed/students/doctype/guardian/guardian.js
@@ -17,7 +17,16 @@ frappe.ui.form.on("Guardian", {
 				frappe.call({
 					method: "ifitwala_ed.students.doctype.guardian.guardian.create_guardian_user",
 					args: { guardian: frm.doc.name }
-				}).then(() => frm.reload_doc());
+				}).then((r) => {
+					frm.reload_doc();
+					// Show portal link for convenience
+					const portal_url = "/portal";
+					frappe.msgprint({
+						title: __("Guardian Portal Ready"),
+						message: __(`Guardian user created. They can access their portal at: <a href="${portal_url}" target="_blank">${portal_url}</a>`),
+						indicator: "green"
+					});
+				});
 			});
 		}
 	},

--- a/ifitwala_ed/students/doctype/guardian/guardian.py
+++ b/ifitwala_ed/students/doctype/guardian/guardian.py
@@ -158,7 +158,7 @@ class Guardian(Document):
 			user.save()
 
 			# Set home_page so guardian is routed to portal on login
-			frappe.db.set_value("User", user.name, "home_page", "/portal", update_modified=False)
+			frappe.db.set_value("User", user.name, "home_page", "/portal/guardian", update_modified=False)
 
 		except Exception as e:
 			frappe.log_error(f"Error creating user for guardian {self.name}: {e}")

--- a/ifitwala_ed/students/doctype/guardian/guardian.py
+++ b/ifitwala_ed/students/doctype/guardian/guardian.py
@@ -157,6 +157,9 @@ class Guardian(Document):
 			user.add_roles("Guardian")
 			user.save()
 
+			# Set home_page so guardian is routed to portal on login
+			frappe.db.set_value("User", user.name, "home_page", "/portal", update_modified=False)
+
 		except Exception as e:
 			frappe.log_error(f"Error creating user for guardian {self.name}: {e}")
 			frappe.throw(_("Error creating user for this guardian. Check Error Log."))

--- a/ifitwala_ed/students/doctype/guardian/test_guardian.py
+++ b/ifitwala_ed/students/doctype/guardian/test_guardian.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2024, François de Ryckel and Contributors
 # See license.txt
 
-# import frappe
+import frappe
 from frappe.tests.utils import FrappeTestCase
 
 
@@ -13,7 +13,7 @@ class TestGuardianUserCreation(FrappeTestCase):
 	"""Test guardian user creation and portal routing."""
 
 	def test_create_guardian_user_sets_home_page(self):
-		"""Creating a guardian user should set their home_page to /portal."""
+		"""Creating a guardian user should set their home_page to /portal/guardian."""
 		# Create a guardian without a user first
 		guardian = frappe.new_doc("Guardian")
 		guardian.guardian_first_name = "Test"
@@ -36,7 +36,7 @@ class TestGuardianUserCreation(FrappeTestCase):
 		roles = [r.role for r in user.roles]
 		self.assertIn("Guardian", roles)
 
-		# MOST IMPORTANT: Verify home_page is set to /portal
+		# MOST IMPORTANT: Verify home_page is set to /portal/guardian for automatic portal routing
 		self.assertEqual(user.home_page, "/portal/guardian")
 
 		# Verify guardian record was updated with user link

--- a/ifitwala_ed/students/doctype/guardian/test_guardian.py
+++ b/ifitwala_ed/students/doctype/guardian/test_guardian.py
@@ -7,3 +7,74 @@ from frappe.tests.utils import FrappeTestCase
 
 class TestGuardian(FrappeTestCase):
 	pass
+
+
+class TestGuardianUserCreation(FrappeTestCase):
+	"""Test guardian user creation and portal routing."""
+
+	def test_create_guardian_user_sets_home_page(self):
+		"""Creating a guardian user should set their home_page to /portal."""
+		# Create a guardian without a user first
+		guardian = frappe.new_doc("Guardian")
+		guardian.guardian_first_name = "Test"
+		guardian.guardian_last_name = "Guardian Portal"
+		guardian.guardian_email = "test_guardian_portal@example.com"
+		guardian.save()
+
+		# Verify no user exists yet
+		self.assertFalse(guardian.user)
+		self.assertFalse(frappe.db.exists("User", guardian.guardian_email))
+
+		# Create the user via the guardian method
+		user_name = guardian.create_guardian_user()
+
+		# Verify user was created
+		self.assertTrue(frappe.db.exists("User", user_name))
+		user = frappe.get_doc("User", user_name)
+
+		# Verify Guardian role was assigned
+		roles = [r.role for r in user.roles]
+		self.assertIn("Guardian", roles)
+
+		# MOST IMPORTANT: Verify home_page is set to /portal
+		self.assertEqual(user.home_page, "/portal")
+
+		# Verify guardian record was updated with user link
+		guardian.reload()
+		self.assertEqual(guardian.user, user_name)
+
+		# Cleanup
+		frappe.delete_doc("Guardian", guardian.name, force=True)
+		frappe.delete_doc("User", user_name, force=True)
+
+	def test_create_guardian_user_links_existing_user(self):
+		"""If user already exists, it should be linked and home_page set."""
+		# Create user first
+		user = frappe.new_doc("User")
+		user.email = "existing_guardian_user@example.com"
+		user.first_name = "Existing"
+		user.last_name = "Guardian"
+		user.enabled = 1
+		user.add_roles("Guardian")
+		user.save()
+
+		# Create guardian pointing to same email
+		guardian = frappe.new_doc("Guardian")
+		guardian.guardian_first_name = "Existing"
+		guardian.guardian_last_name = "Guardian"
+		guardian.guardian_email = user.email
+		guardian.save()
+
+		# Try to create user - should link existing
+		result = guardian.create_guardian_user()
+
+		# Should return existing user name
+		self.assertEqual(result, user.email)
+
+		# Guardian should be linked
+		guardian.reload()
+		self.assertEqual(guardian.user, user.email)
+
+		# Cleanup
+		frappe.delete_doc("Guardian", guardian.name, force=True)
+		frappe.delete_doc("User", user.email, force=True)

--- a/ifitwala_ed/students/doctype/guardian/test_guardian.py
+++ b/ifitwala_ed/students/doctype/guardian/test_guardian.py
@@ -37,7 +37,7 @@ class TestGuardianUserCreation(FrappeTestCase):
 		self.assertIn("Guardian", roles)
 
 		# MOST IMPORTANT: Verify home_page is set to /portal
-		self.assertEqual(user.home_page, "/portal")
+		self.assertEqual(user.home_page, "/portal/guardian")
 
 		# Verify guardian record was updated with user link
 		guardian.reload()


### PR DESCRIPTION
## Summary

Guardians with the 'Guardian' role were not being redirected after login, causing them to land on Desk (/app) instead of the Guardian Portal.

## Changes

- **api/users.py**: Added explicit Guardian handling in `redirect_user_to_entry_portal()`
  - Redirects Guardians to `/portal` (SPA router handles guardian-home via `defaultPortal`)
  - Sets `User.home_page` for persistence
  - Respects explicit `home_page` choices if already set
  
- **api/test_users.py**: Added unit tests for Guardian redirect behavior
  - `test_guardian_redirects_to_portal()`
  - `test_guardian_respects_existing_home_page()`

- **docs/spa/04_login_routing.md**: Added engineering documentation for login routing priority and patterns

## Routing Priority (Documented)

1. Student → `/sp` (always)
2. **Guardian → `/portal`** ← This fix
3. Employee → `/portal/staff`
4. Admissions Applicant → `/admissions`

## Testing

- New unit tests verify redirect path and persistence
- Tests verify opt-in respect (existing home_page not overwritten)

Fixes #8