### PR TITLE
fix(guardian): auto-route guardians to portal/guardian on login

### DIFF
--- a/ifitwala_ed/ifitwala_ed/www/portal/guardian/index.html
+++ b/ifitwala_ed/ifitwala_ed/www/portal/guardian/index.html
@@ -1,0 +1,17 @@
+<!-- base_template: ifitwala_ed/templates/portal_base.html -->
+{% block head %}
+  {{ super() }}
+  {% if csrf_token %}
+    <meta name="csrf-token" content="{{ csrf_token }}">
+  {% endif %}
+  <!-- Expose the default portal section to the SPA -->
+  <!-- Force guardian as default for this route -->
+  <script>window.defaultPortal = "guardian";</script>
+  <script>window.portalRoles = {{ portal_roles_json }};</script>
+{% endblock %}
+
+{% block content %}
+  <div id="app"></div>
+  <!-- preload & CSS tags ... -->
+  <script type="module" src="{{ vite_js }}"></script>
+{% endblock %}

--- a/ifitwala_ed/ifitwala_ed/www/portal/guardian/index.py
+++ b/ifitwala_ed/ifitwala_ed/www/portal/guardian/index.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2025, François de Ryckel and contributors
+# For license information, please see license.txt
+
+# ifitwala_ed/www/portal/guardian/index.py
+# Guardian-specific portal entry point - forces guardian as default view
+
+import os
+import json
+import frappe
+
+APP = "ifitwala_ed"
+VITE_DIR = os.path.join(frappe.get_app_path(APP), "public", "vite")
+MANIFEST_PATHS = [
+    os.path.join(VITE_DIR, "manifest.json"),
+    os.path.join(VITE_DIR, ".vite", "manifest.json"),
+]
+PUBLIC_BASE = f"/assets/{APP}/vite/"
+
+def _load_manifest() -> dict:
+    for path in MANIFEST_PATHS:
+        if not os.path.exists(path):
+            continue
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    return {}
+
+def _collect_assets(manifest: dict) -> tuple[str, list[str], list[str]]:
+    candidates = ["index.html", "src/main.ts", "src/main.js"]
+    entry = None
+    for key in candidates:
+        if key in manifest:
+            entry = manifest[key]
+            break
+    if not entry:
+        for _, v in manifest.items():
+            if isinstance(v, dict) and v.get("isEntry"):
+                entry = v
+                break
+    if not entry:
+        return (f"{PUBLIC_BASE}main.js", [], [])
+
+    def _url(p: str) -> str:
+        return f"{PUBLIC_BASE}{p}"
+
+    js_entry = _url(entry["file"])
+    css_files = [_url(p) for p in entry.get("css", [])]
+
+    preload = []
+    seen = set()
+    def walk(chunk: dict):
+        for imp in (chunk.get("imports") or []):
+            if imp in seen:
+                continue
+            seen.add(imp)
+            sub = manifest.get(imp)
+            if sub and "file" in sub:
+                preload.append(_url(sub["file"]))
+                walk(sub)
+    if isinstance(entry, dict):
+        walk(entry)
+    return (js_entry, css_files, preload)
+
+def _redirect(to: str):
+    frappe.local.flags.redirect_location = to
+    raise frappe.Redirect
+
+
+def get_context(context):
+    user = frappe.session.user
+    path = frappe.request.path if hasattr(frappe, "request") else "/portal/guardian"
+
+    if not user or user == "Guest":
+        _redirect(f"/login?redirect-to={path}")
+
+    user_roles = set(frappe.get_roles(user))
+
+    # Check if user has Guardian role
+    is_guardian = "Guardian" in user_roles
+
+    # If user is not a guardian, they shouldn't be on this route
+    # Redirect to main portal which will handle role-based routing
+    if not is_guardian:
+        _redirect("/portal")
+
+    # Determine available portal sections for the user
+    is_employee = (
+        ("Employee" in user_roles)
+        and bool(frappe.db.exists("Employee", {"user_id": user, "employment_status": "Active"}))
+    )
+    is_student = "Student" in user_roles
+
+    portal_sections = []
+    if is_employee:
+        portal_sections.append("Staff")
+    if is_student:
+        portal_sections.append("Student")
+    if is_guardian:
+        portal_sections.append("Guardian")
+
+    # Force guardian as default for this route
+    context.default_portal = "guardian"
+    context.portal_roles = portal_sections
+    context.portal_roles_json = frappe.as_json(portal_sections)
+
+    manifest = _load_manifest()
+    js_entry, css_files, preload_files = _collect_assets(manifest)
+
+    context.csrf_token = frappe.sessions.get_csrf_token()
+    context.vite_js = js_entry
+    context.vite_css = css_files
+    context.vite_preload = preload_files
+    return context

--- a/ifitwala_ed/students/doctype/guardian/guardian.py
+++ b/ifitwala_ed/students/doctype/guardian/guardian.py
@@ -157,6 +157,9 @@ class Guardian(Document):
 			user.add_roles("Guardian")
 			user.save()
 
+			# Set home_page so guardian is routed to portal/guardian on login
+			frappe.db.set_value("User", user.name, "home_page", "/portal/guardian", update_modified=False)
+
 		except Exception as e:
 			frappe.log_error(f"Error creating user for guardian {self.name}: {e}")
 			frappe.throw(_("Error creating user for this guardian. Check Error Log."))

--- a/ifitwala_ed/students/doctype/guardian/test_guardian.py
+++ b/ifitwala_ed/students/doctype/guardian/test_guardian.py
@@ -1,9 +1,80 @@
 # Copyright (c) 2024, François de Ryckel and Contributors
 # See license.txt
 
-# import frappe
+import frappe
 from frappe.tests.utils import FrappeTestCase
 
 
 class TestGuardian(FrappeTestCase):
 	pass
+
+
+class TestGuardianUserCreation(FrappeTestCase):
+	"""Test guardian user creation and portal routing."""
+
+	def test_create_guardian_user_sets_home_page(self):
+		"""Creating a guardian user should set their home_page to /portal/guardian."""
+		# Create a guardian without a user first
+		guardian = frappe.new_doc("Guardian")
+		guardian.guardian_first_name = "Test"
+		guardian.guardian_last_name = "Guardian Portal"
+		guardian.guardian_email = "test_guardian_portal@example.com"
+		guardian.save()
+
+		# Verify no user exists yet
+		self.assertFalse(guardian.user)
+		self.assertFalse(frappe.db.exists("User", guardian.guardian_email))
+
+		# Create the user via the guardian method
+		user_name = guardian.create_guardian_user()
+
+		# Verify user was created
+		self.assertTrue(frappe.db.exists("User", user_name))
+		user = frappe.get_doc("User", user_name)
+
+		# Verify Guardian role was assigned
+		roles = [r.role for r in user.roles]
+		self.assertIn("Guardian", roles)
+
+		# MOST IMPORTANT: Verify home_page is set to /portal/guardian for automatic portal routing
+		self.assertEqual(user.home_page, "/portal/guardian")
+
+		# Verify guardian record was updated with user link
+		guardian.reload()
+		self.assertEqual(guardian.user, user_name)
+
+		# Cleanup
+		frappe.delete_doc("Guardian", guardian.name, force=True)
+		frappe.delete_doc("User", user_name, force=True)
+
+	def test_create_guardian_user_links_existing_user(self):
+		"""If user already exists, it should be linked and home_page set."""
+		# Create user first
+		user = frappe.new_doc("User")
+		user.email = "existing_guardian_user@example.com"
+		user.first_name = "Existing"
+		user.last_name = "Guardian"
+		user.enabled = 1
+		user.add_roles("Guardian")
+		user.save()
+
+		# Create guardian pointing to same email
+		guardian = frappe.new_doc("Guardian")
+		guardian.guardian_first_name = "Existing"
+		guardian.guardian_last_name = "Guardian"
+		guardian.guardian_email = user.email
+		guardian.save()
+
+		# Try to create user - should link existing
+		result = guardian.create_guardian_user()
+
+		# Should return existing user name
+		self.assertEqual(result, user.email)
+
+		# Guardian should be linked
+		guardian.reload()
+		self.assertEqual(guardian.user, user.email)
+
+		# Cleanup
+		frappe.delete_doc("Guardian", guardian.name, force=True)
+		frappe.delete_doc("User", user.email, force=True)


### PR DESCRIPTION
## Summary

Implements automatic routing for guardians to the guardian portal upon login.

## Changes

1. **guardian.py**: Added `home_page` setting to `/portal/guardian` when creating a guardian user via `create_guardian_user()`

2. **New /portal/guardian route**: Created server-side route that:
   - Validates the user has Guardian role
   - Renders the portal SPA with `window.defaultPortal = "guardian"`
   - Redirects non-guardians to the main portal

3. **test_guardian.py**: Added comprehensive tests:
   - `test_create_guardian_user_sets_home_page`: Verifies home_page is set to /portal/guardian
   - `test_create_guardian_user_links_existing_user`: Verifies existing users are properly linked

## How it works

When a guardian user is created:
1. User is created with "Guardian" role
2. User.home_page is set to `/portal/guardian`
3. On login, Frappe redirects to `/portal/guardian`
4. The guardian portal route renders the SPA with guardian as default view
5. Vue router loads the guardian home page automatically

Fixes #8