### PR TITLE
feat: implement guardian login redirect with staff priority

### DIFF
--- a/ifitwala_ed/api/test_users.py
+++ b/ifitwala_ed/api/test_users.py
@@ -1,0 +1,145 @@
+# Copyright (c) 2026, François de Ryckel and contributors
+# For license information, please see license.txt
+
+# ifitwala_ed/api/test_users.py
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from ifitwala_ed.api.users import redirect_user_to_entry_portal, STAFF_ROLES
+
+
+class TestUserRedirect(FrappeTestCase):
+	"""Test login redirect logic for different user types."""
+
+	def test_guardian_redirects_to_portal(self):
+		"""Guardians should be redirected to /portal/guardian on login."""
+		# Create test user with Guardian role
+		user = frappe.new_doc("User")
+		user.email = "test_guardian_redirect@example.com"
+		user.first_name = "Test"
+		user.last_name = "Guardian"
+		user.enabled = 1
+		user.add_roles("Guardian")
+		user.save()
+
+		# Create Guardian record linked to user
+		guardian = frappe.new_doc("Guardian")
+		guardian.guardian_first_name = "Test"
+		guardian.guardian_last_name = "Guardian"
+		guardian.guardian_email = user.email
+		guardian.user = user.email
+		guardian.save()
+
+		# Simulate login
+		frappe.set_user(user.email)
+		frappe.local.response = {}
+
+		# Call redirect function
+		redirect_user_to_entry_portal()
+
+		# Assert redirect to /portal/guardian
+		self.assertEqual(frappe.local.response.get("home_page"), "/portal/guardian")
+		self.assertEqual(frappe.local.response.get("redirect_to"), "/portal/guardian")
+		self.assertEqual(frappe.local.response.get("type"), "redirect")
+
+		# Verify home_page was set on User
+		user.reload()
+		self.assertEqual(user.home_page, "/portal/guardian")
+
+		# Cleanup
+		frappe.set_user("Administrator")
+		frappe.delete_doc("Guardian", guardian.name, force=True)
+		frappe.delete_doc("User", user.email, force=True)
+
+	def test_guardian_respects_existing_home_page(self):
+		"""Guardians with explicit home_page choice should not be overridden."""
+		# Create test user with Guardian role and explicit home_page
+		user = frappe.new_doc("User")
+		user.email = "test_guardian_custom@example.com"
+		user.first_name = "Test"
+		user.last_name = "Guardian Custom"
+		user.home_page = "/app"
+		user.enabled = 1
+		user.add_roles("Guardian")
+		user.save()
+
+		# Create Guardian record
+		guardian = frappe.new_doc("Guardian")
+		guardian.guardian_first_name = "Test"
+		guardian.guardian_last_name = "Guardian Custom"
+		guardian.guardian_email = user.email
+		guardian.user = user.email
+		guardian.save()
+
+		# Simulate login
+		frappe.set_user(user.email)
+		frappe.local.response = {}
+
+		# Call redirect function
+		redirect_user_to_entry_portal()
+
+		# Assert NO redirect was set (respects explicit /app choice)
+		self.assertNotIn("home_page", frappe.local.response)
+
+		# Verify home_page was NOT changed
+		user.reload()
+		self.assertEqual(user.home_page, "/app")
+
+		# Cleanup
+		frappe.set_user("Administrator")
+		frappe.delete_doc("Guardian", guardian.name, force=True)
+		frappe.delete_doc("User", user.email, force=True)
+
+	def test_guardian_with_staff_role_priority(self):
+		"""Guardians with staff roles should NOT be redirected to guardian portal.
+
+		Staff roles take priority over Guardian routing. A user who is both
+		a guardian and has a staff role (e.g., Teacher) should not be
+		redirected to /portal/guardian.
+		"""
+		# Create test user with both Guardian and Teacher roles
+		user = frappe.new_doc("User")
+		user.email = "test_guardian_teacher@example.com"
+		user.first_name = "Test"
+		user.last_name = "Guardian Teacher"
+		user.enabled = 1
+		user.add_roles("Guardian", "Teacher")
+		user.save()
+
+		# Create Guardian record linked to user
+		guardian = frappe.new_doc("Guardian")
+		guardian.guardian_first_name = "Test"
+		guardian.guardian_last_name = "Guardian Teacher"
+		guardian.guardian_email = user.email
+		guardian.user = user.email
+		guardian.save()
+
+		# Simulate login
+		frappe.set_user(user.email)
+		frappe.local.response = {}
+
+		# Call redirect function
+		redirect_user_to_entry_portal()
+
+		# Assert NO guardian redirect was set (staff priority)
+		self.assertNotIn("home_page", frappe.local.response)
+		self.assertNotEqual(frappe.local.response.get("redirect_to"), "/portal/guardian")
+
+		# Cleanup
+		frappe.set_user("Administrator")
+		frappe.delete_doc("Guardian", guardian.name, force=True)
+		frappe.delete_doc("User", user.email, force=True)
+
+	def test_staff_roles_constant(self):
+		"""Verify STAFF_ROLES contains expected roles."""
+		expected_roles = {
+			"Academic User",
+			"System Manager",
+			"Teacher",
+			"Administrator",
+			"Finance User",
+			"HR User",
+			"HR Manager",
+		}
+		self.assertEqual(STAFF_ROLES, expected_roles)

--- a/ifitwala_ed/api/users.py
+++ b/ifitwala_ed/api/users.py
@@ -5,14 +5,30 @@
 
 import frappe
 
+# Staff roles that take priority over Guardian routing
+STAFF_ROLES = frozenset([
+	"Academic User",
+	"System Manager",
+	"Teacher",
+	"Administrator",
+	"Finance User",
+	"HR User",
+	"HR Manager",
+])
+
+
 def redirect_user_to_entry_portal():
 	"""
 	Authoritative login routing (Option C).
 
 	Policy:
 	- Real students -> /sp (always)
-	- Active employees -> default /portal/staff, but allow opt-in to Desk:
+	- Active employees/staff -> default /portal/staff, but allow opt-in to Desk:
 	  If User.home_page is already set (e.g. /app), we DO NOT override it.
+	- Guardians (non-staff) -> /portal/guardian (staff roles take priority)
+	- Admissions Applicant -> /admissions
+
+	Priority order: Student > Staff > Guardian > Admissions Applicant
 
 	Why:
 	- Desk /app logins can override weak response redirects.
@@ -43,7 +59,8 @@ def redirect_user_to_entry_portal():
 		return
 
 	# ---------------------------------------------------------------
-	# 2) Employees: default /portal/staff (but respect explicit opt-in)
+	# 2) Staff (Employees): default /portal/staff (but respect explicit opt-in)
+	# Staff roles take priority over Guardian
 	# ---------------------------------------------------------------
 	if frappe.db.exists("Employee", {"user_id": user, "employment_status": "Active"}):
 		current_home = (frappe.db.get_value("User", user, "home_page") or "").strip()
@@ -61,9 +78,29 @@ def redirect_user_to_entry_portal():
 		return
 
 	# ---------------------------------------------------------------
-	# 3) Admissions Applicant: always /admissions
+	# 3) Guardians: route to /portal/guardian (if not staff)
+	# Staff check: users with staff roles should not be redirected to guardian portal
 	# ---------------------------------------------------------------
 	roles = set(frappe.get_roles(user))
+	has_staff_role = bool(roles & STAFF_ROLES)
+	is_guardian = frappe.db.exists("Guardian", {"user": user})
+
+	if is_guardian and not has_staff_role:
+		current_home = (frappe.db.get_value("User", user, "home_page") or "").strip()
+
+		if not current_home:
+			_force_redirect("/portal/guardian", also_set_home_page=True)
+		else:
+			if current_home in ("/portal", "/portal/guardian"):
+				_force_redirect("/portal/guardian", also_set_home_page=False)
+			# If home_page is set to something else (e.g. /app), respect it
+			# This allows guardians with desk access to opt-in
+
+		return
+
+	# ---------------------------------------------------------------
+	# 4) Admissions Applicant: always /admissions
+	# ---------------------------------------------------------------
 	if "Admissions Applicant" in roles:
 		current_home = (frappe.db.get_value("User", user, "home_page") or "").strip()
 		if not current_home:

--- a/ifitwala_ed/ifitwala_ed/www/portal/guardian/index.html
+++ b/ifitwala_ed/ifitwala_ed/www/portal/guardian/index.html
@@ -1,0 +1,17 @@
+<!-- base_template: ifitwala_ed/templates/portal_base.html -->
+{% block head %}
+  {{ super() }}
+  {% if csrf_token %}
+    <meta name="csrf-token" content="{{ csrf_token }}">
+  {% endif %}
+  <!-- Expose the default portal section to the SPA -->
+  <!-- Force guardian as default for this route -->
+  <script>window.defaultPortal = "guardian";</script>
+  <script>window.portalRoles = {{ portal_roles_json }};</script>
+{% endblock %}
+
+{% block content %}
+  <div id="app"></div>
+  <!-- preload & CSS tags ... -->
+  <script type="module" src="{{ vite_js }}"></script>
+{% endblock %}

--- a/ifitwala_ed/ifitwala_ed/www/portal/guardian/index.py
+++ b/ifitwala_ed/ifitwala_ed/www/portal/guardian/index.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2025, François de Ryckel and contributors
+# For license information, please see license.txt
+
+# ifitwala_ed/www/portal/guardian/index.py
+# Guardian-specific portal entry point - forces guardian as default view
+
+import os
+import json
+import frappe
+
+APP = "ifitwala_ed"
+VITE_DIR = os.path.join(frappe.get_app_path(APP), "public", "vite")
+MANIFEST_PATHS = [
+    os.path.join(VITE_DIR, "manifest.json"),
+    os.path.join(VITE_DIR, ".vite", "manifest.json"),
+]
+PUBLIC_BASE = f"/assets/{APP}/vite/"
+
+def _load_manifest() -> dict:
+    for path in MANIFEST_PATHS:
+        if not os.path.exists(path):
+            continue
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    return {}
+
+def _collect_assets(manifest: dict) -> tuple[str, list[str], list[str]]:
+    candidates = ["index.html", "src/main.ts", "src/main.js"]
+    entry = None
+    for key in candidates:
+        if key in manifest:
+            entry = manifest[key]
+            break
+    if not entry:
+        for _, v in manifest.items():
+            if isinstance(v, dict) and v.get("isEntry"):
+                entry = v
+                break
+    if not entry:
+        return (f"{PUBLIC_BASE}main.js", [], [])
+
+    def _url(p: str) -> str:
+        return f"{PUBLIC_BASE}{p}"
+
+    js_entry = _url(entry["file"])
+    css_files = [_url(p) for p in entry.get("css", [])]
+
+    preload = []
+    seen = set()
+    def walk(chunk: dict):
+        for imp in (chunk.get("imports") or []):
+            if imp in seen:
+                continue
+            seen.add(imp)
+            sub = manifest.get(imp)
+            if sub and "file" in sub:
+                preload.append(_url(sub["file"]))
+                walk(sub)
+    if isinstance(entry, dict):
+        walk(entry)
+    return (js_entry, css_files, preload)
+
+def _redirect(to: str):
+    frappe.local.flags.redirect_location = to
+    raise frappe.Redirect
+
+
+def get_context(context):
+    user = frappe.session.user
+    path = frappe.request.path if hasattr(frappe, "request") else "/portal/guardian"
+
+    if not user or user == "Guest":
+        _redirect(f"/login?redirect-to={path}")
+
+    user_roles = set(frappe.get_roles(user))
+
+    # Check if user has Guardian role
+    is_guardian = "Guardian" in user_roles
+
+    # If user is not a guardian, they shouldn't be on this route
+    # Redirect to main portal which will handle role-based routing
+    if not is_guardian:
+        _redirect("/portal")
+
+    # Determine available portal sections for the user
+    is_employee = (
+        ("Employee" in user_roles)
+        and bool(frappe.db.exists("Employee", {"user_id": user, "employment_status": "Active"}))
+    )
+    is_student = "Student" in user_roles
+
+    portal_sections = []
+    if is_employee:
+        portal_sections.append("Staff")
+    if is_student:
+        portal_sections.append("Student")
+    if is_guardian:
+        portal_sections.append("Guardian")
+
+    # Force guardian as default for this route
+    context.default_portal = "guardian"
+    context.portal_roles = portal_sections
+    context.portal_roles_json = frappe.as_json(portal_sections)
+
+    manifest = _load_manifest()
+    js_entry, css_files, preload_files = _collect_assets(manifest)
+
+    context.csrf_token = frappe.sessions.get_csrf_token()
+    context.vite_js = js_entry
+    context.vite_css = css_files
+    context.vite_preload = preload_files
+    return context

--- a/ifitwala_ed/students/doctype/guardian/guardian.py
+++ b/ifitwala_ed/students/doctype/guardian/guardian.py
@@ -157,6 +157,9 @@ class Guardian(Document):
 			user.add_roles("Guardian")
 			user.save()
 
+			# Set home_page so guardian is routed to portal/guardian on login
+			frappe.db.set_value("User", user.name, "home_page", "/portal/guardian", update_modified=False)
+
 		except Exception as e:
 			frappe.log_error(f"Error creating user for guardian {self.name}: {e}")
 			frappe.throw(_("Error creating user for this guardian. Check Error Log."))

--- a/ifitwala_ed/students/doctype/guardian/test_guardian.py
+++ b/ifitwala_ed/students/doctype/guardian/test_guardian.py
@@ -1,9 +1,80 @@
 # Copyright (c) 2024, François de Ryckel and Contributors
 # See license.txt
 
-# import frappe
+import frappe
 from frappe.tests.utils import FrappeTestCase
 
 
 class TestGuardian(FrappeTestCase):
 	pass
+
+
+class TestGuardianUserCreation(FrappeTestCase):
+	"""Test guardian user creation and portal routing."""
+
+	def test_create_guardian_user_sets_home_page(self):
+		"""Creating a guardian user should set their home_page to /portal/guardian."""
+		# Create a guardian without a user first
+		guardian = frappe.new_doc("Guardian")
+		guardian.guardian_first_name = "Test"
+		guardian.guardian_last_name = "Guardian Portal"
+		guardian.guardian_email = "test_guardian_portal@example.com"
+		guardian.save()
+
+		# Verify no user exists yet
+		self.assertFalse(guardian.user)
+		self.assertFalse(frappe.db.exists("User", guardian.guardian_email))
+
+		# Create the user via the guardian method
+		user_name = guardian.create_guardian_user()
+
+		# Verify user was created
+		self.assertTrue(frappe.db.exists("User", user_name))
+		user = frappe.get_doc("User", user_name)
+
+		# Verify Guardian role was assigned
+		roles = [r.role for r in user.roles]
+		self.assertIn("Guardian", roles)
+
+		# MOST IMPORTANT: Verify home_page is set to /portal/guardian for automatic portal routing
+		self.assertEqual(user.home_page, "/portal/guardian")
+
+		# Verify guardian record was updated with user link
+		guardian.reload()
+		self.assertEqual(guardian.user, user_name)
+
+		# Cleanup
+		frappe.delete_doc("Guardian", guardian.name, force=True)
+		frappe.delete_doc("User", user_name, force=True)
+
+	def test_create_guardian_user_links_existing_user(self):
+		"""If user already exists, it should be linked and home_page set."""
+		# Create user first
+		user = frappe.new_doc("User")
+		user.email = "existing_guardian_user@example.com"
+		user.first_name = "Existing"
+		user.last_name = "Guardian"
+		user.enabled = 1
+		user.add_roles("Guardian")
+		user.save()
+
+		# Create guardian pointing to same email
+		guardian = frappe.new_doc("Guardian")
+		guardian.guardian_first_name = "Existing"
+		guardian.guardian_last_name = "Guardian"
+		guardian.guardian_email = user.email
+		guardian.save()
+
+		# Try to create user - should link existing
+		result = guardian.create_guardian_user()
+
+		# Should return existing user name
+		self.assertEqual(result, user.email)
+
+		# Guardian should be linked
+		guardian.reload()
+		self.assertEqual(guardian.user, user.email)
+
+		# Cleanup
+		frappe.delete_doc("Guardian", guardian.name, force=True)
+		frappe.delete_doc("User", user.email, force=True)


### PR DESCRIPTION
Implements automatic redirect for guardians to /portal/guardian/ on login.

## Changes

### 
- Added \+STAFF_ROLES\+ constant defining roles that take priority over Guardian routing
- Implemented Guardian redirect logic with staff priority check
- Priority order: Student > Staff > Guardian > Admissions Applicant
- Guardians without staff roles are redirected to \+/portal/guardian/\+
- Respects existing \+home_page\+ settings (allows opt-in to Desk)

###  (new)
- Added comprehensive tests for Guardian redirect functionality
- Tests for staff role priority (dual-role users)
- Tests for respecting explicit home_page choices

## Behavior

| User Type | Redirect Target | Notes |
|-----------|-----------------|-------|
| Student | \+/sp\+ | Always |
| Active Employee | \+/portal/staff\+ | Respects existing \+/app\+ setting |
| Guardian (no staff role) | \+/portal/guardian/\+ | New behavior |
| Guardian + Staff | No redirect (staff priority) | Can manually navigate to portal |
| Admissions Applicant | \+/admissions\+ | If no home_page set |

## Fixes

Closes #8