### PR TITLE
fix: stabilize backend smoke user redirect tests

### DIFF
--- a/ifitwala_ed/api/test_users.py
+++ b/ifitwala_ed/api/test_users.py
@@ -24,6 +24,22 @@ from ifitwala_ed.api.users import (
     sanitize_login_redirect_param,
 )
 
+_REQUIRED_TEST_APPS = ("frappe", "ifitwala_ed")
+_ORIGINAL_GET_INSTALLED_APPS = getattr(frappe, "get_installed_apps", None)
+
+
+def _get_test_installed_apps(*args, **kwargs):
+    apps = []
+    if callable(_ORIGINAL_GET_INSTALLED_APPS):
+        try:
+            apps = list(_ORIGINAL_GET_INSTALLED_APPS(*args, **kwargs) or [])
+        except Exception:
+            apps = []
+    for app_name in _REQUIRED_TEST_APPS:
+        if app_name not in apps:
+            apps.append(app_name)
+    return apps
+
 
 def _admission_settings_has_field(fieldname: str) -> bool:
     if not frappe.db.exists("DocType", "Admission Settings"):
@@ -41,7 +57,9 @@ def _ensure_test_organization() -> str:
             "organization_name": "Redirect Test Org",
             "abbr": f"R{frappe.generate_hash(length=4)}",
         }
-    ).insert(ignore_permissions=True)
+    )
+    doc.flags.skip_coa_setup = True
+    _insert_user(doc)
     return doc.name
 
 
@@ -58,8 +76,21 @@ def _append_role(user_doc, role: str) -> None:
 
 def _new_test_user():
     user = frappe.new_doc("User")
-    user.send_welcome_email = 0
+    user.flags.no_welcome_mail = True
     return user
+
+
+def _insert_user(user_doc):
+    if getattr(user_doc, "doctype", None) != "User":
+        user_doc.insert(ignore_permissions=True)
+        return
+    with (
+        patch.object(user_doc, "send_password_notification"),
+        patch.object(user_doc, "send_welcome_mail_to_user"),
+        patch("frappe.core.doctype.user.user.User.send_password_notification"),
+        patch("frappe.core.doctype.user.user.User.send_welcome_mail_to_user"),
+    ):
+        user_doc.insert(ignore_permissions=True)
 
 
 class TestUserRedirect(FrappeTestCase):
@@ -67,11 +98,17 @@ class TestUserRedirect(FrappeTestCase):
 
     def setUp(self):
         super().setUp()
-        self._welcome_mail_patcher = patch("frappe.core.doctype.user.user.User.send_welcome_mail_to_user")
-        self._welcome_mail_patcher.start()
+        self._installed_apps_patcher = patch.object(
+            frappe,
+            "get_installed_apps",
+            side_effect=_get_test_installed_apps,
+        )
+        self._installed_apps_patcher.start()
+        frappe.set_user("Administrator")
 
     def tearDown(self):
-        self._welcome_mail_patcher.stop()
+        self._installed_apps_patcher.stop()
+        frappe.set_user("Administrator")
         super().tearDown()
 
     def test_strip_redirect_query_removes_redirect_to_params(self):
@@ -116,7 +153,7 @@ class TestUserRedirect(FrappeTestCase):
         user.last_name = "Applicant"
         user.enabled = 1
         _append_role(user, "Admissions Applicant")
-        user.insert(ignore_permissions=True)
+        _insert_user(user)
 
         original_request = getattr(frappe.local, "request", None)
         try:
@@ -143,7 +180,7 @@ class TestUserRedirect(FrappeTestCase):
         user.user_type = "System User"
         _append_role(user, "Employee")
         _append_role(user, "Admissions Applicant")
-        user.insert(ignore_permissions=True)
+        _insert_user(user)
 
         employee = frappe.new_doc("Employee")
         employee.employee_first_name = "Mixed"
@@ -153,7 +190,7 @@ class TestUserRedirect(FrappeTestCase):
         employee.employee_professional_email = user.email
         employee.organization = _ensure_test_organization()
         employee.employment_status = "Active"
-        employee.insert(ignore_permissions=True)
+        _insert_user(employee)
 
         original_request = getattr(frappe.local, "request", None)
         try:
@@ -179,7 +216,7 @@ class TestUserRedirect(FrappeTestCase):
         user.last_name = "Staff"
         user.enabled = 1
         _append_role(user, "Employee")
-        user.insert(ignore_permissions=True)
+        _insert_user(user)
 
         employee = frappe.new_doc("Employee")
         employee.employee_first_name = "Desk"
@@ -189,7 +226,7 @@ class TestUserRedirect(FrappeTestCase):
         employee.employee_professional_email = user.email
         employee.organization = _ensure_test_organization()
         employee.employment_status = "Active"
-        employee.insert(ignore_permissions=True)
+        _insert_user(employee)
 
         original_request = getattr(frappe.local, "request", None)
         try:
@@ -216,7 +253,7 @@ class TestUserRedirect(FrappeTestCase):
         user.first_name = "Test"
         user.last_name = "User"
         user.enabled = 1
-        user.insert(ignore_permissions=True)
+        _insert_user(user)
 
         # Simulate login
         frappe.set_user(user.email)
@@ -241,7 +278,7 @@ class TestUserRedirect(FrappeTestCase):
         user.last_name = "Admissions Applicant"
         user.enabled = 1
         _append_role(user, "Admissions Applicant")
-        user.insert(ignore_permissions=True)
+        _insert_user(user)
 
         try:
             frappe.set_user(user.email)
@@ -265,7 +302,7 @@ class TestUserRedirect(FrappeTestCase):
         user.user_type = "System User"
         _append_role(user, "Employee")
         _append_role(user, "Admissions Applicant")
-        user.insert(ignore_permissions=True)
+        _insert_user(user)
 
         employee = frappe.new_doc("Employee")
         employee.employee_first_name = "Staff"
@@ -275,7 +312,7 @@ class TestUserRedirect(FrappeTestCase):
         employee.employee_professional_email = user.email
         employee.organization = _ensure_test_organization()
         employee.employment_status = "Active"
-        employee.insert(ignore_permissions=True)
+        _insert_user(employee)
 
         frappe.set_user(user.email)
         frappe.local.response = {}
@@ -297,7 +334,7 @@ class TestUserRedirect(FrappeTestCase):
         user.last_name = "Redirect"
         user.enabled = 1
         _append_role(user, "Employee")
-        user.insert(ignore_permissions=True)
+        _insert_user(user)
 
         employee = frappe.new_doc("Employee")
         employee.employee_first_name = "Override"
@@ -307,7 +344,7 @@ class TestUserRedirect(FrappeTestCase):
         employee.employee_professional_email = user.email
         employee.organization = _ensure_test_organization()
         employee.employment_status = "Active"
-        employee.insert(ignore_permissions=True)
+        _insert_user(employee)
 
         frappe.set_user(user.email)
         frappe.local.response = {}
@@ -332,7 +369,7 @@ class TestUserRedirect(FrappeTestCase):
         user.last_name = "Page"
         user.enabled = 1
         _append_role(user, "Employee")
-        user.insert(ignore_permissions=True)
+        _insert_user(user)
 
         employee = frappe.new_doc("Employee")
         employee.employee_first_name = "Home"
@@ -342,7 +379,7 @@ class TestUserRedirect(FrappeTestCase):
         employee.employee_professional_email = user.email
         employee.organization = _ensure_test_organization()
         employee.employment_status = "Active"
-        employee.insert(ignore_permissions=True)
+        _insert_user(employee)
 
         class _LoginManager:
             def __init__(self):
@@ -371,7 +408,7 @@ class TestUserRedirect(FrappeTestCase):
         user.last_name = "Logging"
         user.enabled = 1
         _append_role(user, "Employee")
-        user.insert(ignore_permissions=True)
+        _insert_user(user)
 
         employee = frappe.new_doc("Employee")
         employee.employee_first_name = "Trace"
@@ -381,7 +418,7 @@ class TestUserRedirect(FrappeTestCase):
         employee.employee_professional_email = user.email
         employee.organization = _ensure_test_organization()
         employee.employment_status = "Active"
-        employee.insert(ignore_permissions=True)
+        _insert_user(employee)
 
         original_request = getattr(frappe.local, "request", None)
         original_form_dict = getattr(frappe, "form_dict", None)
@@ -421,7 +458,7 @@ class TestUserRedirect(FrappeTestCase):
         user.last_name = "Guardian"
         user.enabled = 1
         _append_role(user, "Guardian")
-        user.insert(ignore_permissions=True)
+        _insert_user(user)
 
         # Create Guardian record linked to user
         guardian = frappe.new_doc("Guardian")
@@ -460,7 +497,7 @@ class TestUserRedirect(FrappeTestCase):
         user.last_name = "Admissions"
         user.enabled = 1
         _append_role(user, "Admissions Family")
-        user.insert(ignore_permissions=True)
+        _insert_user(user)
 
         try:
             frappe.db.set_single_value("Admission Settings", "admissions_access_mode", "Family Workspace")
@@ -491,7 +528,7 @@ class TestUserRedirect(FrappeTestCase):
         user.last_name = "Student"
         user.enabled = 1
         _append_role(user, "Student")
-        user.insert(ignore_permissions=True)
+        _insert_user(user)
 
         # Create Student record linked to user
         student = frappe.new_doc("Student")
@@ -503,7 +540,7 @@ class TestUserRedirect(FrappeTestCase):
         previous_in_import = bool(getattr(frappe.flags, "in_import", False))
         frappe.flags.in_import = True
         try:
-            student.insert(ignore_permissions=True)
+            _insert_user(student)
         finally:
             frappe.flags.in_import = previous_in_import
 
@@ -532,7 +569,7 @@ class TestUserRedirect(FrappeTestCase):
         user.last_name = "Staff"
         user.enabled = 1
         _append_role(user, "Employee")
-        user.insert(ignore_permissions=True)
+        _insert_user(user)
 
         # Create Employee record linked to user
         employee = frappe.new_doc("Employee")
@@ -543,7 +580,7 @@ class TestUserRedirect(FrappeTestCase):
         employee.employee_professional_email = user.email
         employee.organization = _ensure_test_organization()
         employee.employment_status = "Active"
-        employee.insert(ignore_permissions=True)
+        _insert_user(employee)
 
         # Simulate login
         frappe.set_user(user.email)
@@ -568,7 +605,7 @@ class TestUserRedirect(FrappeTestCase):
         user.first_name = "Employee"
         user.last_name = "RoleOnly"
         user.enabled = 1
-        user.insert(ignore_permissions=True)
+        _insert_user(user)
 
         frappe.set_user(user.email)
         frappe.local.response = {}
@@ -590,7 +627,7 @@ class TestUserRedirect(FrappeTestCase):
         user.last_name = "RoleOnly"
         user.enabled = 1
         _append_role(user, "Teacher")
-        user.insert(ignore_permissions=True)
+        _insert_user(user)
 
         frappe.set_user(user.email)
         frappe.local.response = {}
@@ -610,7 +647,7 @@ class TestUserRedirect(FrappeTestCase):
         user.first_name = "Active"
         user.last_name = "Employee"
         user.enabled = 1
-        user.insert(ignore_permissions=True)
+        _insert_user(user)
 
         employee = frappe.new_doc("Employee")
         employee.employee_first_name = "Active"
@@ -620,7 +657,7 @@ class TestUserRedirect(FrappeTestCase):
         employee.employee_professional_email = user.email
         employee.organization = _ensure_test_organization()
         employee.employment_status = "Active"
-        employee.insert(ignore_permissions=True)
+        _insert_user(employee)
 
         frappe.set_user(user.email)
         frappe.local.response = {}
@@ -642,7 +679,7 @@ class TestUserRedirect(FrappeTestCase):
         user.first_name = "Temporary"
         user.last_name = "Leave"
         user.enabled = 1
-        user.insert(ignore_permissions=True)
+        _insert_user(user)
 
         employee = frappe.new_doc("Employee")
         employee.employee_first_name = "Temporary"
@@ -652,7 +689,7 @@ class TestUserRedirect(FrappeTestCase):
         employee.employee_professional_email = user.email
         employee.organization = _ensure_test_organization()
         employee.employment_status = "Temporary Leave"
-        employee.insert(ignore_permissions=True)
+        _insert_user(employee)
 
         frappe.set_user(user.email)
         frappe.local.response = {}
@@ -674,7 +711,7 @@ class TestUserRedirect(FrappeTestCase):
         user.last_name = "AdminRole"
         user.enabled = 1
         _append_role(user, "Administrator")
-        user.insert(ignore_permissions=True)
+        _insert_user(user)
 
         employee = frappe.new_doc("Employee")
         employee.employee_first_name = "Temporary"
@@ -684,7 +721,7 @@ class TestUserRedirect(FrappeTestCase):
         employee.employee_professional_email = user.email
         employee.organization = _ensure_test_organization()
         employee.employment_status = "Temporary Leave"
-        employee.insert(ignore_permissions=True)
+        _insert_user(employee)
 
         frappe.set_user(user.email)
         frappe.local.response = {}
@@ -706,8 +743,9 @@ class TestUserRedirect(FrappeTestCase):
         user.first_name = "Missing"
         user.last_name = "Link"
         user.enabled = 1
-        _append_role(user, "Employee")
-        user.insert(ignore_permissions=True)
+        _append_role(user, "Teacher")
+        _insert_user(user)
+        frappe.clear_cache(user=user.name)
 
         employee = frappe.new_doc("Employee")
         employee.employee_first_name = "Missing"
@@ -716,7 +754,7 @@ class TestUserRedirect(FrappeTestCase):
         employee.employee_professional_email = email
         employee.organization = _ensure_test_organization()
         employee.employment_status = "Active"
-        employee.insert(ignore_permissions=True)
+        _insert_user(employee)
 
         frappe.set_user(user.email)
         frappe.local.response = {}
@@ -740,7 +778,7 @@ class TestUserRedirect(FrappeTestCase):
         user.first_name = "Unlinked"
         user.last_name = "Active"
         user.enabled = 1
-        user.insert(ignore_permissions=True)
+        _insert_user(user)
 
         employee = frappe.new_doc("Employee")
         employee.employee_first_name = "Unlinked"
@@ -749,7 +787,7 @@ class TestUserRedirect(FrappeTestCase):
         employee.employee_professional_email = email
         employee.organization = _ensure_test_organization()
         employee.employment_status = "Active"
-        employee.insert(ignore_permissions=True)
+        _insert_user(employee)
 
         frappe.set_user(user.email)
         frappe.local.response = {}
@@ -786,7 +824,7 @@ class TestUserRedirect(FrappeTestCase):
         user.last_name = "Home"
         user.enabled = 1
         _append_role(user, "Employee")
-        user.insert(ignore_permissions=True)
+        _insert_user(user)
 
         employee = frappe.new_doc("Employee")
         employee.employee_first_name = "Web"
@@ -796,7 +834,7 @@ class TestUserRedirect(FrappeTestCase):
         employee.employee_professional_email = user.email
         employee.organization = _ensure_test_organization()
         employee.employment_status = "Active"
-        employee.insert(ignore_permissions=True)
+        _insert_user(employee)
 
         frappe.set_user(user.email)
         self.assertEqual(get_website_user_home_page(), "/hub/staff")
@@ -818,7 +856,7 @@ class TestUserRedirect(FrappeTestCase):
         user.last_name = "Safe"
         user.enabled = 1
         _append_role(user, "Employee")
-        user.insert(ignore_permissions=True)
+        _insert_user(user)
 
         employee = frappe.new_doc("Employee")
         employee.employee_first_name = "Logout"
@@ -828,7 +866,7 @@ class TestUserRedirect(FrappeTestCase):
         employee.employee_professional_email = user.email
         employee.organization = _ensure_test_organization()
         employee.employment_status = "Active"
-        employee.insert(ignore_permissions=True)
+        _insert_user(employee)
 
         frappe.set_user(user.email)
         frappe.local.response = {}
@@ -878,11 +916,17 @@ class TestUserRedirect(FrappeTestCase):
 class TestUserQueries(FrappeTestCase):
     def setUp(self):
         super().setUp()
-        self._welcome_mail_patcher = patch("frappe.core.doctype.user.user.User.send_welcome_mail_to_user")
-        self._welcome_mail_patcher.start()
+        self._installed_apps_patcher = patch.object(
+            frappe,
+            "get_installed_apps",
+            side_effect=_get_test_installed_apps,
+        )
+        self._installed_apps_patcher.start()
+        frappe.set_user("Administrator")
 
     def tearDown(self):
-        self._welcome_mail_patcher.stop()
+        self._installed_apps_patcher.stop()
+        frappe.set_user("Administrator")
         super().tearDown()
 
     def test_get_users_with_role_returns_only_enabled_matching_users(self):
@@ -907,7 +951,7 @@ class TestUserQueries(FrappeTestCase):
         employee_user.last_name = "Match"
         employee_user.enabled = 1
         _append_role(employee_user, "Employee")
-        employee_user.insert(ignore_permissions=True)
+        _insert_user(employee_user)
 
         disabled_employee = _new_test_user()
         disabled_employee.email = f"test_employee_query_disabled_{frappe.generate_hash(length=6)}@example.com"
@@ -915,7 +959,7 @@ class TestUserQueries(FrappeTestCase):
         disabled_employee.last_name = "Disabled"
         disabled_employee.enabled = 0
         _append_role(disabled_employee, "Employee")
-        disabled_employee.insert(ignore_permissions=True)
+        _insert_user(disabled_employee)
 
         non_employee_user = _new_test_user()
         non_employee_user.email = f"test_employee_query_other_{frappe.generate_hash(length=6)}@example.com"
@@ -923,7 +967,7 @@ class TestUserQueries(FrappeTestCase):
         non_employee_user.last_name = "Teacher"
         non_employee_user.enabled = 1
         _append_role(non_employee_user, "Teacher")
-        non_employee_user.insert(ignore_permissions=True)
+        _insert_user(non_employee_user)
         ensure_has_role(employee_user.email, "Employee")
         ensure_has_role(disabled_employee.email, "Employee")
         ensure_has_role(non_employee_user.email, "Teacher")


### PR DESCRIPTION
## Summary
- port the existing  harness fixes onto a clean branch from 
- suppress User insert side effects during redirect tests with a shared  helper
- keep required installed-app state stable in the test harness and avoid heavy organization bootstrap in test setup

## Why
 failed on [run 24811432635](https://github.com/fderyckel/ifitwala_ed/actions/runs/24811432635) in .
The failure is test setup drift, not a portal-routing contract change: the current follow-up branch already contains the necessary harness hardening, so this PR ports that proven test-only fix back onto .

## Verification
- 
- rely on the PR GitHub Actions run for full Frappe smoke verification
